### PR TITLE
Move preferences.json to preferences.js

### DIFF
--- a/preferences.js
+++ b/preferences.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "devtools": {
     "devedition": {
       "promo": {
@@ -134,6 +134,10 @@
         "type": 128
       },
       "promise": {
+        "value": false,
+        "type": 128
+      },
+      "auto-pretty-print": {
         "value": false,
         "type": 128
       }

--- a/sham/services/prefs.js
+++ b/sham/services/prefs.js
@@ -1,4 +1,4 @@
-let DEFAULTS = require("../../preferences.json");
+let DEFAULTS = require("../../preferences.js");
 // TODO Can make this localStorage or something in the future?
 let storage = JSON.parse(JSON.stringify(DEFAULTS));
 


### PR DESCRIPTION
I'd like to avoid this... but at this point it's something I need to do to use `npm link ff-devtools-lib`. Lets explore this a bit more before we merge.
